### PR TITLE
Fix attributeerror when using field with mysql

### DIFF
--- a/src/django_ciemailfield.py
+++ b/src/django_ciemailfield.py
@@ -26,6 +26,7 @@ class CiEmailField(EmailField):
 
     def get_db_prep_value(self, value, connection, prepared=False):
         if connection.vendor != 'postgresql':
-            value = value.lower()
+            if isinstance(value, basestring):  # value might be None
+                value = value.lower()
         return super(CiEmailField, self).get_db_prep_value(
             value, connection, prepared)

--- a/src/django_ciemailfield.py
+++ b/src/django_ciemailfield.py
@@ -4,6 +4,23 @@ from django.db.models.signals import pre_migrate
 from django.dispatch import receiver
 
 
+# Python 2/3 compatibility. Credit to https://github.com/oxplot/fysom/issues/1
+try:
+    unicode = unicode
+except NameError:
+    # 'unicode' is undefined, must be Python 3
+    str = str
+    unicode = str
+    bytes = bytes
+    basestring = (str, bytes)
+else:
+    # 'unicode' exists, must be Python 2
+    str = str
+    unicode = unicode
+    bytes = str
+    basestring = basestring
+
+
 @receiver(pre_migrate)
 def setup_postgres_extensions(sender, **kwargs):
     conn = connections[kwargs['using']]


### PR DESCRIPTION
This PR fixes an attribute error that's triggered when using this field with mysql (and probably sqlite) and the trying to run the migrations to add that field to one of your models.

Previously this happened:
     AttributeError: 'NoneType' object has no attribute 'lower'

Solution was to verify that what we are trying to add is actually a string (or unicode) before trying to call the "lower()" method.
